### PR TITLE
Remove standard library modules from requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,4 @@
-argparse
-contextlib
-io
-logging
 PyQt5>=5.15.0
-struct
-typing
 Pillow>=9.0.0
 kiwisolver>=1.3.0
 PyQt5-stubs>=5.15.0


### PR DESCRIPTION
The removed modules are all available from the standard library, and as such should not be in `requirements.txt`.

I noticed this because running `pip install -r requirements.txt` showed me the following error, since there is no `contextlib` package on pypi:

```
Collecting argparse (from -r requirements.txt (line 1))
  Downloading argparse-1.4.0-py2.py3-none-any.whl.metadata (2.8 kB)

ERROR: Could not find a version that satisfies the requirement contextlib (from versions: none)
ERROR: No matching distribution found for contextlib
````

Also, note that the version of argparse that was installed is actually [this](https://pypi.org/project/argparse/) obsolete/third party package from pypi, rather than [standard library module](https://docs.python.org/3/library/argparse.html) which does not need to be installed with pip.
